### PR TITLE
Remove the path components from the URL sent as origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 `Starscream` adheres to [Semantic Versioning](http://semver.org/).
 
+#### [2.0.2](https://github.com/daltoniam/Starscream/tree/2.0.2)
+
+Fix for the Swift Package Manager.
+
+Fixed: 
+[#277](https://github.com/daltoniam/Starscream/issues/277)
+
 #### [2.0.1](https://github.com/daltoniam/Starscream/tree/2.0.1)
 
 Bug fixes.

--- a/Source/Info-tvOS.plist
+++ b/Source/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -166,7 +166,9 @@ open class WebSocket : NSObject, StreamDelegate {
     /// Used for setting protocols.
     public init(url: URL, protocols: [String]? = nil) {
         self.url = url
-        self.origin = url.absoluteString
+        if let hostUrl = URL (string: "/", relativeTo: url) {
+            self.origin = hostUrl.absoluteString
+        }
         writeQueue.maxConcurrentOperationCount = 1
         optionalProtocols = protocols
     }

--- a/Starscream.podspec
+++ b/Starscream.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Starscream"
-  s.version      = "2.0.1"
+  s.version      = "2.0.2"
   s.summary      = "A conforming WebSocket RFC 6455 client library in Swift for iOS and OSX."
   s.homepage     = "https://github.com/daltoniam/Starscream"
   s.license      = 'Apache License, Version 2.0'

--- a/Starscream.xcodeproj/xcshareddata/xcschemes/Starscream.xcscheme
+++ b/Starscream.xcodeproj/xcshareddata/xcschemes/Starscream.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Starscream.xcodeproj/xcshareddata/xcschemes/StarscreamOSX.xcscheme
+++ b/Starscream.xcodeproj/xcshareddata/xcschemes/StarscreamOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Starscream.xcodeproj/xcshareddata/xcschemes/StarscreamTests.xcscheme
+++ b/Starscream.xcodeproj/xcshareddata/xcschemes/StarscreamTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Starscream.xcodeproj/xcshareddata/xcschemes/StarscreamTv.xcscheme
+++ b/Starscream.xcodeproj/xcshareddata/xcschemes/StarscreamTv.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/SimpleTest/SimpleTest/ViewController.swift
+++ b/examples/SimpleTest/SimpleTest/ViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import Starscream
 
 class ViewController: UIViewController, WebSocketDelegate {
-    var socket = WebSocket(url: URL(string: "ws://localhost:8080/")!, protocols: ["chat", "superchat"])
+    var socket = WebSocket(url: URL(string: "ws://localhost:8080/api")!, protocols: ["chat", "superchat"])
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/examples/SimpleTest/ws-server.rb
+++ b/examples/SimpleTest/ws-server.rb
@@ -8,7 +8,7 @@ EM.run {
       puts "origin: #{handshake.origin}"
       puts "headers: #{handshake.headers}"
 
-      ws.send "Hello Client, you connected to #{handshake.path}"
+      ws.send "Hello Client, you connected to #{handshake.path} with origin #{handshake.origin}"
     }
 
     ws.onerror do |error|


### PR DESCRIPTION
This fixes issue #287. The origin is a URI indicating the server from which the request initiated. It does not include any path information, but only the server name.